### PR TITLE
Solver defaults

### DIFF
--- a/CfdCaseWriterFoam.py
+++ b/CfdCaseWriterFoam.py
@@ -52,20 +52,27 @@ class CfdCaseWriterFoam:
         self.bc_group = CfdTools.getConstraintGroup(analysis_obj)
         self.mesh_generated = False
 
-        self.case_folder = self.solver_obj.WorkingDir + os.path.sep + self.solver_obj.InputCaseName
-        self.mesh_file_name = self.case_folder + os.path.sep + self.solver_obj.InputCaseName + u".unv"
-        if self.solver_obj.HeatTransfering:
-            self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj))
-        else:
-            self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj))
-        self.builder.createCase()
-
     def write_case(self, updating=False):
         """ Write_case() will collect case setings, and finally build a runnable case
         """
         FreeCAD.Console.PrintMessage("Start to write case to folder {}\n".format(self.solver_obj.WorkingDir))
         _cwd = os.curdir
         os.chdir(self.solver_obj.WorkingDir)  # pyFoam can not write to cwd if FreeCAD is started NOT from terminal
+
+        # Perform initialisation here rather than __init__ in case of path changes
+        self.case_folder = os.path.join(self.solver_obj.WorkingDir, self.solver_obj.InputCaseName)
+        self.mesh_file_name = os.path.join(self.case_folder, self.solver_obj.InputCaseName, u".unv")
+
+        # Create initial case from defaults
+        # Until module is integrated, store the defaults inside the module directory rather than the resource dir
+        if self.solver_obj.HeatTransfering:
+            #self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj), os.path.join(FreeCAD.getResourceDir(), "Mod", "Cfd", "defaults", "chtMultiRegionSimpleFoam"))
+            self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj), os.path.join(CfdTools.get_module_path(), "data", "defaults", "chtMultiRegionSimpleFoam"))
+        else:
+            #self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj), os.path.join(FreeCAD.getResourceDir(), "Mod", "Cfd", "defaults", "simpleFoam"))
+            self.builder = fcb.BasicBuilder(self.case_folder, CfdTools.getSolverSettings(self.solver_obj), os.path.join(CfdTools.get_module_path(), "data", "defaults", "simpleFoam"))
+        self.builder.createCase()
+
         self.write_mesh()
 
         self.write_material()

--- a/CfdCaseWriterFoam.py
+++ b/CfdCaseWriterFoam.py
@@ -157,7 +157,7 @@ class CfdCaseWriterFoam:
                                                 }
 
             bc_settings.append(bc_dict)
-        self.builder.internalFields = {'p': 0.0, 'U': (0, 0, 0.001)}  # must set a nonzero for velocity field
+        self.builder.internalFields = {'p': 0.0, 'U': (0, 0, 0)}
         self.builder.boundaryConditions = bc_settings
 
     def write_solver_control(self):

--- a/FoamCaseBuilder/BasicBuilder.py
+++ b/FoamCaseBuilder/BasicBuilder.py
@@ -694,11 +694,8 @@ class BasicBuilder(object):
 
     ################################## solver control #####################################        
     def setupSolverControl(self):
-        # PyFoam always run into trouble when loading such file
-        #pRefValue must be set, since some case does not contains such requested
-        #residual control, currently all default from tutorial case setup, but can be setup
-        createRawFoamFile(self._casePath, "system", "fvSolution", getFvSolutionTemplate())
-        #createRawFoamFile(self._casePath, "system", "fvSchemes", getFvSchemesTemplate())
+        f = ParsedParameterFile(os.path.join(self._casePath, "system", "fvSolution"))
+        # Currently does nothing
 
     def setupRelaxationFactors(self, pressure_factor=0.1, velocity_factor=0.1, other_factor=0.3):
         # '.*' apply to all variables
@@ -1398,3 +1395,4 @@ class BasicBuilder(object):
             f["boundaryField"][bcName] = {}
             f["boundaryField"][bcName]["type"] = subtype
             f.writeFile()
+

--- a/FoamCaseBuilder/utility.py
+++ b/FoamCaseBuilder/utility.py
@@ -344,6 +344,13 @@ def createCaseFromTemplate(output_path, source_path, backup_path=None):
             copySettingsFromExistentCase(output_path, source_path)
         else:
             raise Exception("Error: tutorial case folder: {} not found".format(source_path))
+    elif source_path.find("defaults")>=0:
+        if not os.path.isabs(source_path):  # create case from existent case folder
+            source_path = os.path.join(getFoamDir(), os.path.sep, source_path)
+        if os.path.exists(source_path):
+            copySettingsFromExistentCase(output_path, source_path)
+        else:
+            raise Exception("Error: defaults case folder: {} not found".format(source_path))
     elif source_path[-4:] == ".zip":  # zipped case template,outdated
         template_path = source_path
         if os.path.isfile(template_path):
@@ -353,7 +360,7 @@ def createCaseFromTemplate(output_path, source_path, backup_path=None):
         else:
             raise Exception("Error: template case file {} not found".format(source_path))
     else:
-        raise Exception('Error: template {} is not a tutorials case path or zipped file'.format(source_path))
+        raise Exception('Error: template {} is not a tutorials case path, defaults case path, or zipped file'.format(source_path))
     #foamCleanPolyMesh
     mesh_dir = os.path.join(output_path, "constant", "polyMesh")
     if os.path.isdir(mesh_dir):
@@ -389,8 +396,14 @@ def createCaseFromScratch(output_path, solver_name):
 def copySettingsFromExistentCase(output_path, source_path):
     """build case structure from string template, both folder paths must existent
     """
-    shutil.copytree(source_path + os.path.sep + "constant", output_path + os.path.sep + "constant")
     shutil.copytree(source_path + os.path.sep + "system", output_path + os.path.sep + "system")
+    source_const = os.path.join(source_path, "constant")
+    dest_const = os.path.join(output_path, "constant")
+    if os.path.exists(source_const):
+        shutil.copytree(source_const, dest_const)
+    else:
+        if not os.path.exists(dest_const):
+            os.makedirs(dest_const)
     #runFoamCommand('foamCopySettins  {} {}'.format(source_path, output_path))
     #foamCopySettins: Copy OpenFOAM settings from one case to another, without copying the mesh or results
     if os.path.exists(source_path + os.path.sep + "0"):

--- a/data/defaults/simpleFoam/system/controlDict
+++ b/data/defaults/simpleFoam/system/controlDict
@@ -1,0 +1,41 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      controlDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+application     simpleFoam;
+
+startFrom       latestTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         1000;
+
+deltaT          1;
+
+writeControl    timeStep;
+
+writeInterval   100;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  8;
+
+writeCompression uncompressed;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable true;
+
+
+// ************************************************************************* //

--- a/data/defaults/simpleFoam/system/fvSchemes
+++ b/data/defaults/simpleFoam/system/fvSchemes
@@ -1,0 +1,65 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fvSchemes;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+ddtSchemes
+{
+    default         steadyState;
+}
+
+gradSchemes
+{
+    // Limit gradient to improve stability when bad cells encountered 
+    // (0 = no limiting; 1 = do not exceed surrounding cells)
+    default         cellLimited Gauss linear 0.95;
+}
+
+divSchemes
+{
+    default         none;
+    // Use second-order accurate convection
+    // Bounded schemes for steady-state solution
+    div(phi,U)      bounded Gauss linearUpwindV grad(U);
+    div(phi,k)      bounded Gauss linearUpwind grad(k);
+    div(phi,epsilon)  bounded Gauss linearUpwind grad(epsilon);
+    div(R)          Gauss linear;
+    div(phi,R)      bounded Gauss linearUpwind grad(R);
+    div(phi,omega)  bounded Gauss linearUpwind grad(omega);
+    div(phi,nuTilda) bounded Gauss linearUpwind grad(nuTilda);
+    div(phi,v2)     bounded Gauss linearUpwind grad(v2);
+    div((nuEff*dev2(T(grad(U))))) Gauss linear;
+}
+
+laplacianSchemes
+{
+    // Limited explicit correction to the surface normal gradient,
+    // for stability in highly non-orthogonal cells.
+    // (0 = uncorrected, fully implicit; 1 = full correction)
+    default         Gauss linear limited 0.3;
+}
+
+interpolationSchemes
+{
+    default         linear;
+}
+
+snGradSchemes
+{
+    // Limited explicit correction to the surface normal gradient,
+    // for stability in highly non-orthogonal cells.
+    // (0 = uncorrected, fully implicit; 1 = full correction)
+    default         limited 0.3;
+}
+
+wallDist
+{
+    method meshWave;
+}
+
+
+// ************************************************************************* //

--- a/data/defaults/simpleFoam/system/fvSolution
+++ b/data/defaults/simpleFoam/system/fvSolution
@@ -1,0 +1,100 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    p
+    {
+        solver           GAMG;
+        tolerance        1e-7;
+        relTol           0.01;
+        smoother         GaussSeidel;
+        nPreSweeps       0;
+        nPostSweeps      2;
+        cacheAgglomeration on;
+        agglomerator     faceAreaPair;
+        nCellsInCoarsestLevel 10;
+        mergeLevels      1;
+    }
+
+    Phi
+    {
+        $p;
+    }
+
+    U
+    {
+        solver           smoothSolver;
+        smoother         GaussSeidel;
+        tolerance        1e-8;
+        relTol           0.1;
+        nSweeps          1;
+    }
+
+   "(k|epsilon|omega|f|v2)"
+   {
+        solver           smoothSolver;
+        smoother         GaussSeidel;
+        tolerance        1e-8;
+        relTol           0.1;
+        nSweeps          1;
+    }
+
+    nuTilda
+    {
+        solver          smoothSolver;
+        smoother        GaussSeidel;
+        nSweeps         2;
+        tolerance       1e-08;
+        relTol          0.1;
+    }
+}
+
+SIMPLE
+{
+    // Non-orthogonal correctors for robustness on tet meshes
+    nNonOrthogonalCorrectors 3;
+
+    consistent yes;
+    residualControl
+    {
+        p 0.01;
+        U 0.001;
+        "(k|epsilon|omega|f|v2)" 0.001;
+    }
+    pRefValue 0;
+    pRefCell 0;
+}
+
+potentialFlow
+{
+    nNonOrthogonalCorrectors 10;
+}
+
+relaxationFactors
+{
+    // Conservative settings to solve reliably on bad
+    // meshes
+    equations
+    {
+        U               0.6;
+        ".*"            0.6;
+    }
+    fields
+    {
+        p               0.3;
+    }
+}
+
+cache
+{
+    grad(U);
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
Create cases from user-editable scheme templates
    
The idea is to have fvSolution and fvSchemes data in a best-practice
database that is available to users to edit. At present this
just takes the form of copying fvSchemes and fvSolution from
this location, but in future different dictionaries could be
merged in order to easily maintain best-practice data for different
functionalities.
    
The data is stored in <Cfd_mod_dir>/data/defaults under the solver name.
